### PR TITLE
dnsmasq: remove pid file after service has been stopped

### DIFF
--- a/package/network/services/dnsmasq/files/dnsmasq.init
+++ b/package/network/services/dnsmasq/files/dnsmasq.init
@@ -740,4 +740,5 @@ stop_service() {
 		ln -s /tmp/resolv.conf.auto /tmp/resolv.conf
 	}
 	rm -f /var/run/dnsmasq.*.dhcp
+	rm -f /var/run/dnsmasq/dnsmasq.pid
 }


### PR DESCRIPTION
no stale pid file after dnsmasq full stop